### PR TITLE
Allow stubbing method with parameter named 'call'.

### DIFF
--- a/tests/mocked/tests/mocking.d
+++ b/tests/mocked/tests/mocking.d
@@ -454,3 +454,16 @@ unittest
     static assert(is(typeof(Mocker().mock!Dependency())));
     static assert(is(typeof(Mocker().stub!Dependency())));
 }
+
+@("mocks method with a parameter called 'call'")
+unittest
+{
+    static class Dependency
+    {
+        void foo(int call)
+        {
+        }
+    }
+    Mocker().mock!Dependency();
+    static assert(is(typeof(Mocker().stub!Dependency())));
+}


### PR DESCRIPTION
See https://issues.dlang.org/show_bug.cgi?id=21343