### PR TITLE
Provide short configure type for comparators

### DIFF
--- a/.github/workflows/dlang.yml
+++ b/.github/workflows/dlang.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup DMD
       uses: dlang-community/setup-dlang@v1
       with:
-        compiler: dmd-2.096.0
+        compiler: dmd-2.100.0
 
     - name: Cache
       uses: actions/cache@v2
@@ -47,7 +47,7 @@ jobs:
     - name: Setup DMD
       uses: dlang-community/setup-dlang@v1
       with:
-        compiler: dmd-2.096.0
+        compiler: dmd-2.100.0
 
     - name: Cache
       uses: actions/cache@v2
@@ -56,5 +56,5 @@ jobs:
         key: ${{ runner.os }}-audit-${{ hashFiles('**/dub.json') }}
         restore-keys: ${{ runner.os }}-audit-
 
-    - run: dub fetch dscanner --version=0.11.0
+    - run: dub fetch dscanner --version=0.12.1
     - run: dub run dscanner -- --styleCheck source tests

--- a/README.md
+++ b/README.md
@@ -210,18 +210,18 @@ assert(mock.toString() == expected);
 ### Custom argument comparator
 
 You can provide a function, which will be used to compare two objects of a
-specific type. Use `configure` instead of the `Mocker` to create a custom mocker
-instance. `configure` takes a tuple of `Comparator`s, so you can specify as many
+specific type.
+Use `Configure` instead of the `Mocker` to create a custom mocker instance.
+`Configure` takes a tuple of "comparators", so you can specify as many
 comparators as you like, but they aren't allowed to conflict, so the types in
 question should be distinct types.
 
-Every `Comparator` has a single template parameter which is a function actually
-used for the comparison. This function should have exactly two arguments of the
-same type and return a boolean value.
+Every "comparator" is a function actually used for the comparison.
+This function should have exactly two arguments of the same type and return a boolean value.
 
 ```d
 import mocked;
-import std.math : fabs;
+import std.math : abs;
 
 class Dependency
 {
@@ -233,9 +233,9 @@ class Dependency
 // This function is used to compare two floating point numbers that don't
 // match exactly.
 alias approxComparator = (float a, float b) {
-    return fabs(a - b) <= 0.1;
+    return abs(a - b) <= 0.1;
 };
-auto mocker = configure!(Comparator!approxComparator);
+Configure!approxComparator mocker;
 auto builder = mocker.mock!Dependency;
 
 builder.expect.call(1.01);

--- a/dub.json
+++ b/dub.json
@@ -20,8 +20,8 @@
 			],
 			"mainSourceFile": "tests/app.d",
 			"dependencies": {
-				"dshould": ">=1.4.3",
-				"unit-threaded": ">=1.0.11"
+				"dshould": ">=1.5.1",
+				"unit-threaded": ">=1.1.0"
 			}
 		}
 	]

--- a/source/mocked/mocker.d
+++ b/source/mocked/mocker.d
@@ -260,6 +260,9 @@ auto configure(Args...)()
     return Factory!(Options!Args)();
 }
 
+/// ditto
+alias Configure(Args...) = Factory!(Options!(staticMap!(Comparator, Args)));
+
 /**
  * A class through which one creates mock objects and manages expectations
  * about calls to their methods.

--- a/source/mocked/package.d
+++ b/source/mocked/package.d
@@ -2,5 +2,5 @@ module mocked;
 
 public import mocked.error : UnexpectedCallError, UnexpectedArgumentError,
        OutOfOrderCallError, ExpectationViolationException;
-public import mocked.mocker : configure, Factory, Mocked, Mocker, Stubbed;
+public import mocked.mocker : Configure, configure, Factory, Mocked, Mocker, Stubbed;
 public import mocked.option : Comparator;

--- a/tests/app.d
+++ b/tests/app.d
@@ -1,8 +1,11 @@
 import unit_threaded;
 
+import mocked.tests.alien;
 import mocked.tests.expectations;
 import mocked.tests.mocking;
+import mocked.tests.option;
 import mocked.tests.readme;
+import mocked.tests.stub;
 
 mixin runTestsMain!(
     mocked.tests.alien,

--- a/tests/mocked/tests/readme.d
+++ b/tests/mocked/tests/readme.d
@@ -27,7 +27,7 @@ unittest
 
 unittest
 {
-    import std.math : fabs;
+    import std.math : abs;
 
     static class Dependency
     {
@@ -39,9 +39,9 @@ unittest
     // This function is used to compare two floating point numbers that don't
     // match exactly.
     alias approxComparator = (float a, float b) {
-        return fabs(a - b) <= 0.1;
+        return abs(a - b) <= 0.1;
     };
-    auto mocker = configure!(Comparator!approxComparator);
+    Configure!approxComparator mocker;
     auto builder = mocker.mock!Dependency;
 
     builder.expect.call(1.01);

--- a/tests/mocked/tests/stub.d
+++ b/tests/mocked/tests/stub.d
@@ -53,7 +53,7 @@ unittest
 @("can use custom comparator")
 unittest
 {
-    import std.math : fabs;
+    import std.math : abs;
 
     static class Dependency
     {
@@ -64,7 +64,7 @@ unittest
     }
 
     alias approxComparator = (float a, float b) {
-        return fabs(a - b) <= 0.1;
+        return abs(a - b) <= 0.1;
     };
     auto mocker = configure!(Comparator!approxComparator);
     auto builder = mocker.stub!Dependency;
@@ -74,6 +74,42 @@ unittest
     auto stub = builder.get;
 
     stub.call(1.02).should.be(true);
+}
+
+@("can configure custom comparator with type")
+unittest
+{
+    import std.math : abs;
+
+    static class Dependency
+    {
+        public bool call(float)
+        {
+            return false;
+        }
+
+        public bool call(int)
+        {
+            return false;
+        }
+    }
+
+    alias approxComparator = (float a, float b) {
+        return abs(a - b) <= 0.1;
+    };
+    alias absComparator = (int a, int b) {
+        return abs(a) == abs(b);
+    };
+    Configure!(approxComparator, absComparator) mocker;
+    auto builder = mocker.stub!Dependency;
+
+    builder.stub.call(1.01).returns(true);
+    builder.stub.call(-1).returns(true);
+
+    auto stub = builder.get;
+
+    stub.call(1.02).should.be(true);
+    stub.call(1).should.be(true);
 }
 
 @("stubs const methods")


### PR DESCRIPTION
Provides a type to define a mocker with comparators: `Configure!(comparator1, comparator2) mocker`.